### PR TITLE
Actually include dsdt.aml in acpi_override

### DIFF
--- a/generate_and_apply_patch.sh
+++ b/generate_and_apply_patch.sh
@@ -26,6 +26,7 @@ mv dsdt_patched.dsl dsdt.dsl
 iasl -tc -ve dsdt.dsl
 # genereate override
 mkdir -p kernel/firmware/acpi
+cp dsdt.aml kernel/firmware/acpi
 find kernel | cpio -H newc --create > acpi_override
 
 # copy override file to boot partition


### PR DESCRIPTION
I don't have hardware to test this, but the `cp` command was included in [the blog post](https://delta-xi.net/#056), and I can't see how could the script possibly work without it.