### PR TITLE
Fix typo in bootloader update message

### DIFF
--- a/generate_and_apply_patch.sh
+++ b/generate_and_apply_patch.sh
@@ -32,4 +32,4 @@ sudo cp acpi_override ${BOOT}
 
 # optimistic check for bootloader configuration
 grep -qir acpi_override ${BOOT} || \
-    echo "Don't forget up update your bootloader config."
+    echo "Don't forget to update your bootloader config."


### PR DESCRIPTION
There was a typo in the message reminding the user to update their bootloader configuration. This patch simply fixes that typo.