### PR TITLE
Added support for systems with pacman instead of apt-get

### DIFF
--- a/generate_and_apply_patch.sh
+++ b/generate_and_apply_patch.sh
@@ -7,10 +7,18 @@ IRFS_HOOK="/etc/initramfs-tools/hooks/acpi_override.sh"
 cd `mktemp -d`
 
 # Make sure we have required tools on systems with apt
-if [ -x $(which apt-get) ]; then
+if [ -x "$(command -v apt-get)" ]; then
+	
 	echo "[*] Installing required tools"
 	sudo apt-get -y install acpica-tools cpio
+
+# Make sure we have required tools on systems with pacman
+elif [ -x "$(command -v pacman)" ]; then
+	echo "[*] Installing required tools"
+	sudo pacman --noconfirm -S acpica cpio
+
 fi
+
 
 # extract dsdt
 echo "[*] Dumping DSDT"


### PR DESCRIPTION
Added support for pacman based systems instead of apt-get and changed the use of `which` to `command` for the reasons explained [here](https://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script)